### PR TITLE
fix: supply chain security remediation (rancher-security#1650)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 MAINTAINER Rancher Support support@rancher.com
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -yq --no-install-recommends \
+ca-certificates \
 curl \
 msmtp \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-##Installing kubectl
-RUN curl -k -LO https://storage.googleapis.com/kubernetes-release/release/`curl -k -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && mv kubectl /bin/kubectl && chmod +x /bin/kubectl
+ARG KUBECTL_VERSION=v1.36.0
+ARG KUBECTL_SUM=123d8c8844f46b1244c547fffb3c17180c0c26dac9890589fe7e67763298748e
+
+RUN curl -sLf "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /tmp/kubectl && \
+    echo "${KUBECTL_SUM}  /tmp/kubectl" | sha256sum -c - && \
+    mv /tmp/kubectl /bin/kubectl && \
+    chmod +x /bin/kubectl
 
 ADD *.sh /usr/bin/
 RUN chmod +x /usr/bin/*.sh


### PR DESCRIPTION
## Summary

Addresses findings from the supply chain risk scan reported in rancher/rancher-security#1650.

- **Pin base image to digest** — upgrades `ubuntu:18.04` (EOL) to `ubuntu:24.04` pinned to `sha256:c4a8d5503...`, preventing tag mutation attacks (§3.7)
- **Add `ca-certificates`** — required for TLS verification on the minimal Ubuntu image
- **Remove `curl -k`** — was silently disabling SSL certificate verification on both curl calls
- **Pin kubectl version** — replaces dynamic `stable.txt` resolution at build time with `v1.36.0`
- **Add sha256 checksum validation** — verifies the kubectl binary with `sha256sum -c -` before installing

## Test plan

- [x] `docker build` succeeds with correct checksum
- [x] `docker run --rm systems-info:test kubectl version --client` returns `v1.36.0`
- [x] Build fails as expected when `KUBECTL_SUM` is tampered with